### PR TITLE
Fix Privacy Policy link and add a Back to top btn

### DIFF
--- a/infinite-library/assets/css/infinite-library-styles.css
+++ b/infinite-library/assets/css/infinite-library-styles.css
@@ -71,6 +71,16 @@ ol {
   font-family: "Lexend", sans-serif;
   max-width: fit-content !important;
 }
+.back-to-top {
+  color: #3a7d73;
+  background: transparent;
+  border: none;
+}
+.back-to-top img {
+  vertical-align: unset;
+  margin-right: 5px;
+}
+
 .company-address {
   margin-left: 40pt;
 }

--- a/infinite-library/assets/images/back-to-top.svg
+++ b/infinite-library/assets/images/back-to-top.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="20" viewBox="0 0 14 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.004 5.05V19M1 11L7 5L13 11M1 1H13" stroke="#3A7D73" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/infinite-library/privacy_policy.html
+++ b/infinite-library/privacy_policy.html
@@ -454,6 +454,11 @@
               privacy@learningtapestry.com .
             </p>
           </div>
+          <div class="d-flex justify-content-end">
+            <button class="back-to-top" onclick="scrollToTop()">
+              <img src="assets/images/back-to-top.svg" />BACK TO THE TOP
+            </button>
+          </div>
         </div>
       </section>
     </main>
@@ -470,5 +475,12 @@
 
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+
+    <!-- Back to top button -->
+    <script>
+      function scrollToTop() {
+        window.scrollTo(0, 0);
+      }
+    </script>
   </body>
 </html>

--- a/infinite-library/privacy_policy.html
+++ b/infinite-library/privacy_policy.html
@@ -117,7 +117,7 @@
               Each time you use our App, you consent to the collection, use and
               storage of the collected information as described in this Privacy
               Policy. Please read it carefully and contact us at
-              privacy@learningtapestry.com > if you have any questions.
+              privacy@learningtapestry.com if you have any questions.
             </p>
 
             <h3><a name="anchor1"></a>1. What information do we collect</h3>

--- a/infinite-library/terms_of_service.html
+++ b/infinite-library/terms_of_service.html
@@ -601,6 +601,11 @@
               Covina, California 91723 <br />
               Email: support@learningtapestry.com
             </div>
+            <div class="d-flex justify-content-end">
+              <button class="back-to-top" onclick="scrollToTop()">
+                <img src="assets/images/back-to-top.svg" />BACK TO THE TOP
+              </button>
+            </div>
           </div>
         </div>
       </section>
@@ -614,5 +619,12 @@
 
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+
+    <!-- Back to top button -->
+    <script>
+      function scrollToTop() {
+        window.scrollTo(0, 0);
+      }
+    </script>
   </body>
 </html>

--- a/infinite-library/terms_of_service.html
+++ b/infinite-library/terms_of_service.html
@@ -111,7 +111,10 @@
             </p>
             <p>
               THESE TERMS OF SERVICE AND
-              <a href="/privacy_policy.html">PRIVACY POLICY</a>
+              <a
+                href="https://www.learningtapestry.com/infinite-library/privacy_policy.html"
+                >PRIVACY POLICY</a
+              >
               (ALTOGETHER, THESE “TERMS”) SET FORTH THE LEGALLY BINDING TERMS
               AND CONDITIONS THAT GOVERN YOUR USE OF OUR APP (THE APP, OUR
               “SERVICES”). BY ACCESSING OR USING OUR SERVICES, YOU ARE ACCEPTING


### PR DESCRIPTION
PP link inside the ToS page was a relative link and redirected to a 404 page.
So, I replaced it with a complete URL.

In addition, a _Back to The Top Button_ was added to the PP and ToS page to improve the UX, similar to what is on the Learning Tapestry website.
<kbd><img width="380" alt="back to top button" src="https://github.com/learningtapestry/www-staging/assets/60038598/d50a4c77-78e8-47c6-9723-abd09f0129b4"></kbd>
