### PR TITLE
Fix carousel on large screens

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1153,3 +1153,9 @@ footer .footer__text {
     width: 60%;
   }
 }
+.carousel-inner {
+  @media (min-width: 2000px) {
+    margin: auto;
+    max-width: 80%;
+  }
+}


### PR DESCRIPTION
Issue: carousel arrows were overlapping the testimonials.
<img width="1024px" alt="arrows overlapping testimonials" src="https://github.com/user-attachments/assets/366618be-2f88-4ac5-9b8e-76f4d43d5200">

Fixed by adding a maximum width for screens wider than 2000px
<img width="1024px" alt="fixed" src="https://github.com/user-attachments/assets/d840ab21-2606-4c96-9505-a9011344722d">

